### PR TITLE
Add support for multiplying dragging speed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ resizable.on('resize', function(){
 | `within` | `document` | Restrict movement within the container. Pass `'parent'` to take parent node. |
 | `draggable` | `false` | Make element [draggable](http://github.com/dfcreative/draggy) as well. Set an object to pass options to draggable. |
 | `css3` | `true` | Use `translate3d` for defining position. |
+| `multiplier` | `1` | Influence the dragging speed by multiplying it with a given value. |
 
 \* Default handles are dependent on the styling of the given element. Inline
 elements will default to `s`, `se`, `e`, while elements that can support full

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function Resizable (el, options) {
 	}
 
 	self.element = el;
+	self.multiplier = options.multiplier || 1;
 
 	extend(self, options);
 
@@ -247,6 +248,10 @@ proto.createHandle = function(handle, direction){
 
 	draggy.on('drag', function () {
 		var coords = draggy.getCoords();
+
+		if (self.multiplier !== 1) {
+			coords = coords.map(n => n * self.multiplier);
+		}
 
 		var prevSize = [
 			el.offsetWidth,


### PR DESCRIPTION
Hi :-), so I see the module expects that the div that should be resized is aligned left. Because it is expanded (made bigger) according to each mouse step/movement for a certain amount.

I now had a situation where I defined center alignment for the div. This way each mouse-step/movement expands the div-widths **twice**  (for each mouse step it gets bigger one step on right border as well as one step on left border). As a result the right div border is not close to the cursor anymore since the center alignment moves it more to the left side (to center align it). 

I added an option to multiply the speed by a custom number. For center alignment this would be 2. I hope it may help other people. Best Pepe