### PR TITLE
Add start and end events

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,6 @@ resize will default to all handles being enabled.
 
 | Name | Description |
 |---|---|
+| `resizestart` | Element resize started. Called on self. |
 | `resize` | Element resized. Called on self. |
+| `resizeend` | Element resize ended. Called on self. |

--- a/index.js
+++ b/index.js
@@ -243,6 +243,10 @@ proto.createHandle = function(handle, direction){
 		for (var h in self.handles){
 			css(self.handles[h], 'cursor', null);
 		}
+
+		//trigger callbacks
+		emit(self, 'resizestart');
+		emit(el, 'resizestart');
 	});
 
 	draggy.on('drag', function () {
@@ -418,6 +422,10 @@ proto.createHandle = function(handle, direction){
 		for (var h in self.handles){
 			css(self.handles[h], 'cursor', self.handles[h].direction + '-resize');
 		}
+
+		//trigger callbacks
+		emit(self, 'resizeend');
+		emit(el, 'resizeend');
 	});
 
 	//append styles

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resizable",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Resizable behaviour for elements",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
We had a use case where we needed to know when the user has finished resizing, so this PR exposes a couple of new events to allow for it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dfcreative/resizable/6)
<!-- Reviewable:end -->
